### PR TITLE
  Fix: Prevent start optimization during file extraction

### DIFF
--- a/A1Evo.html
+++ b/A1Evo.html
@@ -107,6 +107,34 @@ and noninfringement. Use at your own risk.
     box-shadow: 0 14px 30px rgba(21, 128, 61, 0.6);
     transform: translateY(-2px) scale(1.03);
   }
+  .button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    background: linear-gradient(45deg, #6B7280, #6B7280);
+    color: #9CA3AF;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    transform: none;
+  }
+  .button2:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    background: linear-gradient(45deg, #6B7280, #6B7280);
+    color: #9CA3AF;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    transform: none;
+  }
+  .button:disabled:hover {
+    background: linear-gradient(45deg, #6B7280, #6B7280);
+    color: #9CA3AF;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    transform: none;
+  }
+  .button2:disabled:hover {
+    background: linear-gradient(45deg, #6B7280, #6B7280);
+    color: #9CA3AF;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    transform: none;
+  }
   .link-container {
     display: flex;
     justify-content: center;
@@ -956,6 +984,9 @@ async function extractMeasurements() {
     console.info('No file selected.');
     return;
   }
+  
+  // Disable the start optimization button after user confirms file selection
+  document.getElementById('startEvo').disabled = true;
   jName = file.name;
   jType = jName.split('.').pop();
   console.info(`Extracting measurements from ${jName}...`);
@@ -1173,6 +1204,9 @@ async function extractMeasurements() {
       console.error("Measurement extraction and sending failed:", error.message);
       throwError(error.message || "An unexpected error occurred during measurement processing.");
   } finally {
+      // Re-enable the start optimization button after extraction completes or fails
+      document.getElementById('startEvo').disabled = false;
+      
       if (inv_micCal && inv_micCal.length > 0) inv_micCal.length = 0;
   }}
 async function inputFile(file) {


### PR DESCRIPTION
 ## Summary
  Prevents users from accidentally clicking "Start Optimization" while the extract measurements process is running.

  ## Problem
  - Users could click "Start Optimization" while file extraction was in progress
  - This caused errors and poor user experience
  - Button remained enabled even during long extraction operations

  ## Solution
  - Added CSS disabled styling for both button types (`.button` and `.button2`)
  - Moved button disabling logic to after file selection confirmation
  - Ensures button is only disabled when extraction actually starts
  - Added proper cleanup in finally block to re-enable button

  ## Changes Made
  - **CSS**: Added `:disabled` and `:disabled:hover` styles for buttons
  - **JavaScript**: Added button state management in `extractMeasurements()` function
  - **UX**: Button stays enabled if user cancels file dialog

  ## Testing
  - ✅ Button disabled during extraction process
  - ✅ Button re-enabled after completion/failure
  - ✅ Button stays enabled if user cancels file selection
  - ✅ Visual feedback shows grayed-out disabled state

  ## Impact
  - Prevents accidental double-clicks during processing
  - Improves user experience and prevents errors
  - Maintains full functionality for normal workflows
